### PR TITLE
Fix: Correctly reference placeholder image in BookCard

### DIFF
--- a/frontend/src/components/BookCard/BookCard.tsx
+++ b/frontend/src/components/BookCard/BookCard.tsx
@@ -1,3 +1,4 @@
+import bookPlaceholder from '../../assets/bookPlaceholder.png';
 import { useNavigate } from "react-router-dom";
 import { useState } from "react";
 import { toggleFavorite } from "@/services/books";
@@ -55,7 +56,7 @@ export default function BookCard({
       <img
         src={
           imageError || !coverImageUrl
-            ? "/src/assets/bookPlaceholder.png"
+            ? bookPlaceholder
             : coverImageUrl
         }
         alt={title}


### PR DESCRIPTION
Imports the bookPlaceholder.png image directly into the BookCard.tsx component and uses the imported variable in the <img> tag.

This resolves an issue where Vite would not correctly serve the image when it was referenced by a direct path string ('/src/assets/bookPlaceholder.png'). Importing the image allows Vite's build process to handle the asset correctly.